### PR TITLE
Update to read from inputstreams that may not be fully available

### DIFF
--- a/src/main/java/nl/sidnlabs/pcap/PcapReader.java
+++ b/src/main/java/nl/sidnlabs/pcap/PcapReader.java
@@ -236,10 +236,7 @@ public class PcapReader {
 
   protected boolean readBytes(byte[] buf) {
     try {
-      // is.readFully(buf);
-      if (is.read(buf, 0, buf.length) < buf.length) {
-        return false;
-      }
+      is.readFully(buf);
     } catch (EOFException e) {
       // Reached the end of the stream
       caughtEOF = true;


### PR DESCRIPTION
Fixes #19

Changes:
* Change back to using readFully
  * Undoes a change in https://github.com/SIDN/pcap-lib/commit/28d0a90e4dc7efb01a62e51e617399c40ad3fca9